### PR TITLE
Generate diagrams consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Usage
 ```
 _Note: Alternatively build manually as described in the [Build](#build) section below (and move/rename the resulting jar from the target folder)._
 
-2. Run the diagram generator:
+1. Get fonts, if necessary.  At the time of writing, Yugabyte uses _Verdana_.
+
+1. Run the diagram generator:
 
 ```bash
 java -jar rrdiagram.jar <input-file.ebnf> <output-folder>

--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ Usage
 
 1. Get the executable jar
 
-```bash
- wget https://github.com/YugaByte/RRDiagram/releases/download/0.9.4/rrdiagram.jar
-```
-_Note: Alternatively build manually as described in the [Build](#build) section below (and move/rename the resulting jar from the target folder)._
+   ```bash
+    wget https://github.com/YugaByte/RRDiagram/releases/download/0.9.4/rrdiagram.jar
+   ```
+
+   _Note: Alternatively build manually as described in the [Build](#build) section below (and move/rename the resulting jar from the target folder)._
 
 1. Get fonts, if necessary.  At the time of writing, Yugabyte uses _Verdana_.
 
 1. Run the diagram generator:
 
-```bash
-java -jar rrdiagram.jar <input-file.ebnf> <output-folder>
-```
-_Note: run `java -jar rrdiagram.jar` (without arguments) to see help._
+   ```bash
+   java -jar rrdiagram.jar <input-file.ebnf> <output-folder>
+   ```
+
+   _Note: run `java -jar rrdiagram.jar` (without arguments) to see help._
 
 
 For more detailed instructions see the [YugaByte Docs Readme](https://github.com/YugaByte/yugabyte-db/blob/master/docs/README.md).

--- a/README.md
+++ b/README.md
@@ -12,28 +12,9 @@ This is the kind of grammars and diagrams that can get generated:
 https://docs.yugabyte.com/latest/api/ysql/commands/cmd_copy/
 
 Usage
-=======
+=====
 
-1. Get the executable jar
-
-   ```bash
-    wget https://github.com/YugaByte/RRDiagram/releases/download/0.9.4/rrdiagram.jar
-   ```
-
-   _Note: Alternatively build manually as described in the [Build](#build) section below (and move/rename the resulting jar from the target folder)._
-
-1. Get fonts, if necessary.  At the time of writing, Yugabyte uses _Verdana_.
-
-1. Run the diagram generator:
-
-   ```bash
-   java -jar rrdiagram.jar <input-file.ebnf> <output-folder>
-   ```
-
-   _Note: run `java -jar rrdiagram.jar` (without arguments) to see help._
-
-
-For more detailed instructions see the [YugaByte Docs Readme](https://github.com/YugaByte/yugabyte-db/blob/master/docs/README.md).
+See the [Yugabyte docs README](YugaByte/yugabyte-db/docs/README.md#generate-api-syntax-diagrams).
 
 Build
 =====

--- a/RRDiagram/Release/changelog.txt
+++ b/RRDiagram/Release/changelog.txt
@@ -5,6 +5,10 @@ Licence terms: ASL 2.0 (see licence.txt)
 
 ---------------------------------- Change log ----------------------------------
 
+* Version 0.9.4-yb-1 (August 26, 2019):
+
+- Port to Yugabyte docs use-case.
+
 * Version 0.9.4 (October 9, 2017):
 
 - Store original parsed expression in rule.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     
     <groupId>net.nextencia</groupId>
     <artifactId>rrdiagram</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.4-yb-1</version>
     
     <name>RRDiagram</name>
     <description>

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -5,6 +5,7 @@ import net.nextencia.rrdiagram.grammar.model.*;
 import net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagram;
 import net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagramToSVG;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -15,6 +16,8 @@ import java.util.List;
 import java.util.Set;
 
 public class Main {
+
+  public static final String FONTFAMILYNAME = "Verdana";
 
   private static void printHelpAndExit() {
     System.out.println("Usage: java -jar rrdiagram.jar <input-file.ebnf> <output-folder>");
@@ -37,6 +40,11 @@ public class Main {
       printHelpAndExit();
     }
 
+    if (!isFontInstalled()) {
+      logErr("Could not find font: " + FONTFAMILYNAME);
+      System.exit(1);
+    }
+
     String inFileName = args[0];
     String outFolderName = args[1];
     File outFolder = new File(outFolderName);
@@ -46,6 +54,17 @@ public class Main {
     Grammar grammar = btg.convert(in);
 
     regenerateFolder(outFolder, grammar);
+  }
+
+  private static boolean isFontInstalled() {
+    GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+    String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
+    for (String fontFamilyName : fontFamilyNames) {
+      if (fontFamilyName.equals(FONTFAMILYNAME)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static void regenerateFolder(File outFolder, Grammar grammar) throws Exception {

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -5,7 +5,6 @@ import net.nextencia.rrdiagram.grammar.model.*;
 import net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagram;
 import net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagramToSVG;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -16,8 +15,6 @@ import java.util.List;
 import java.util.Set;
 
 public class Main {
-
-  public static final String FONTFAMILYNAME = "Verdana";
 
   private static void printHelpAndExit() {
     System.out.println("Usage: java -jar rrdiagram.jar <input-file.ebnf> <output-folder>");
@@ -40,8 +37,8 @@ public class Main {
       printHelpAndExit();
     }
 
-    if (!isFontInstalled()) {
-      logErr("Could not find font: " + FONTFAMILYNAME);
+    if (!RRDiagramToSVG.isFontInstalled()) {
+      logErr("Could not find font: " + RRDiagramToSVG.FONT_FAMILY_NAME);
       System.exit(1);
     }
 
@@ -54,17 +51,6 @@ public class Main {
     Grammar grammar = btg.convert(in);
 
     regenerateFolder(outFolder, grammar);
-  }
-
-  private static boolean isFontInstalled() {
-    GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
-    String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
-    for (String fontFamilyName : fontFamilyNames) {
-      if (fontFamilyName.equals(FONTFAMILYNAME)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private static void regenerateFolder(File outFolder, Grammar grammar) throws Exception {

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -7,11 +7,12 @@ import net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagramToSVG;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.List;
+import java.util.Set;
 
 public class Main {
 
@@ -154,14 +155,20 @@ public class Main {
 
   private static String getGlobalRulePrefix(File diagFile) {
     StringBuilder sb = new StringBuilder();
-    File file = diagFile.getAbsoluteFile();
-    while (file != null && !file.getName().equals("syntax_resources")) {
-      sb.append("../");
-      file = file.getParentFile();
-    }
-    if (file == null) {
-      logErr("Invalid file path '" + diagFile + "'.\n" +
-                 "Expected to have an ancestor called 'syntax_resources'.");
+    try {
+      File file = diagFile.getCanonicalFile();
+      while (file != null && !file.getName().equals("syntax_resources")) {
+        sb.append("../");
+        file = file.getParentFile();
+      }
+      if (file == null) {
+        logErr("Invalid file path '" + diagFile + "'.\n"
+               + "Expected to have an ancestor called 'syntax_resources'.");
+        System.exit(1);
+      }
+    } catch (IOException exception) {
+      logErr("Caught IOException while trying to get the canonical file of '"
+             + diagFile + "': " + exception);
       System.exit(1);
     }
     sb.append("syntax_resources/grammar_diagrams");

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -10,6 +10,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,6 +61,7 @@ public class Main {
       System.exit(1);
     }
 
+    Arrays.sort(files);
     for (File file : files) {
       if (file.isDirectory()) {
         regenerateFolder(file, grammar);

--- a/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
+++ b/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
@@ -11,6 +11,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
+import java.util.Arrays;
 
 /**
  * @author Christopher Deckers
@@ -22,12 +23,7 @@ public class RRDiagramToSVG {
   public static boolean isFontInstalled() {
     GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
     String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
-    for (String fontFamilyName : fontFamilyNames) {
-      if (fontFamilyName.equals(FONT_FAMILY_NAME)) {
-        return true;
-      }
-    }
-    return false;
+    return (Arrays.binarySearch(fontFamilyNames, FONT_FAMILY_NAME) >= 0);
   }
 
   public String convert(RRDiagram rrDiagram) {

--- a/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
+++ b/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
@@ -9,12 +9,26 @@ package net.nextencia.rrdiagram.grammar.rrdiagram;
 
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
 
 /**
  * @author Christopher Deckers
  */
 public class RRDiagramToSVG {
+
+  public static final String FONT_FAMILY_NAME = "Verdana";
+
+  public static boolean isFontInstalled() {
+    GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+    String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
+    for (String fontFamilyName : fontFamilyNames) {
+      if (fontFamilyName.equals(FONT_FAMILY_NAME)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   public String convert(RRDiagram rrDiagram) {
     return rrDiagram.toSVG(this);
@@ -30,7 +44,7 @@ public class RRDiagramToSVG {
     return connectorColor;
   }
 
-  private Font loopFont = new Font("Verdana", Font.PLAIN, 10);
+  private Font loopFont = new Font(FONT_FAMILY_NAME, Font.PLAIN, 10);
 
   public void setLoopFont(Font loopFont) {
     this.loopFont = loopFont;
@@ -66,7 +80,7 @@ public class RRDiagramToSVG {
     return ruleInsets;
   }
 
-  private Font ruleFont = new Font("Verdana", Font.PLAIN, 12);
+  private Font ruleFont = new Font(FONT_FAMILY_NAME, Font.PLAIN, 12);
 
   public void setRuleFont(Font ruleFont) {
     this.ruleFont = ruleFont;
@@ -126,7 +140,7 @@ public class RRDiagramToSVG {
     return literalInsets;
   }
 
-  private Font literalFont = new Font("Verdana", Font.PLAIN, 12);
+  private Font literalFont = new Font(FONT_FAMILY_NAME, Font.PLAIN, 12);
 
   public void setLiteralFont(Font literalFont) {
     this.literalFont = literalFont;
@@ -186,7 +200,7 @@ public class RRDiagramToSVG {
     return specialSequenceInsets;
   }
 
-  private Font specialSequenceFont = new Font("Verdana", Font.PLAIN, 12);
+  private Font specialSequenceFont = new Font(FONT_FAMILY_NAME, Font.PLAIN, 12);
 
   public void setSpecialSequenceFont(Font specialSequenceFont) {
     this.specialSequenceFont = specialSequenceFont;


### PR DESCRIPTION
Diagrams are sometimes generated with slight differences depending on certain factors: font availability and command line arguments.  The lack of font availability isn't critical as it can fall back on other installed fonts.  The command line argument for _output folder_ can sometimes be passed in a way that breaks links, so this is a more critical fix.  This pull request should make diagram generation much more consistent across devices.