### PR TITLE
add markdown code block language

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <groupId>net.nextencia</groupId>
     <artifactId>rrdiagram</artifactId>
     <version>0.9.4-yb-1</version>
-    
+
     <name>RRDiagram</name>
     <description>
-        RR Diagram allows to generate railroad diagrams (also called syntax diagrams) 
-        from code or from BNF notation. The output format is a very compact SVG image 
+        RR Diagram allows to generate railroad diagrams (also called syntax diagrams)
+        from code or from BNF notation. The output format is a very compact SVG image
         which can be integrated to web pages and where rules can contain links.
     </description>
     <url>https://github.com/Chrriis/RRDiagram</url>
-    
+
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
@@ -22,18 +22,18 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <scm>
         <developerConnection>https://github.com/Chrriis/RRDiagram.git</developerConnection>
         <url>https://github.com/Chrriis/RRDiagram.git</url>
         <connection>git://github.com/Chrriis/RRDiagram.git</connection>
     </scm>
-    
+
     <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/Chrriis/RRDiagram/issues</url>
     </issueManagement>
-    
+
     <developers>
         <developer>
             <name>Christopher Deckers</name>
@@ -43,7 +43,7 @@
             </roles>
         </developer>
     </developers>
-    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -52,7 +52,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -61,8 +61,8 @@
                 <version>3.6.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <debug>true</debug>
                     <debuglevel>lines,vars,source</debuglevel>
                 </configuration>

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -126,7 +126,7 @@ public class Main {
           pw.write("\n```\n");
         */
 
-        pw.write("```\n");
+        pw.write("```ebnf\n");
         pw.write(rule.toYBNF());
         pw.write("\n```\n");
         GrammarToRRDiagram diagram_builder = new GrammarToRRDiagram();
@@ -148,7 +148,7 @@ public class Main {
 
   private static void reGenerateGrammar(File outFile, List<Rule> targetRules) throws Exception {
     PrintWriter pw = new java.io.PrintWriter(outFile);
-    pw.write("```\n");
+    pw.write("```ebnf\n");
     for (int i = 0; i < targetRules.size(); i++) {
       if (i > 0) {
         pw.write("\n");

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -121,7 +121,7 @@ public class Main {
 
         /*
           // Debug mode.
-          pw.write("```\n");
+          pw.write("```\ebnfn");
           pw.write(rule.toBNF(bnf_builder));
           pw.write("\n```\n");
         */


### PR DESCRIPTION
This enables the grammar to be syntax-highlighted in the YB docs.

Also, update pom.xml to specify JDK 1.8.