### PR TITLE
[docs] adjust grammar diagram file output

### DIFF
--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -121,12 +121,12 @@ public class Main {
 
         /*
           // Debug mode.
-          pw.write("```\n");
+          pw.write("```output.ebnf\n");
           pw.write(rule.toBNF(bnf_builder));
           pw.write("\n```\n");
         */
 
-        pw.write("```\n");
+        pw.write("```output.ebnf\n");
         pw.write(rule.toYBNF());
         pw.write("\n```\n");
         GrammarToRRDiagram diagram_builder = new GrammarToRRDiagram();
@@ -148,7 +148,7 @@ public class Main {
 
   private static void reGenerateGrammar(File outFile, List<Rule> targetRules) throws Exception {
     PrintWriter pw = new java.io.PrintWriter(outFile);
-    pw.write("```\n");
+    pw.write("```output.ebnf\n");
     for (int i = 0; i < targetRules.size(); i++) {
       if (i > 0) {
         pw.write("\n");

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -113,6 +113,7 @@ public class Main {
     pw.write("---\n");
     pw.write("title: Grammar Diagrams\n");
     pw.write("summary: Diagrams of the grammar rules.\n");
+    pw.write("type: docs\n");
     pw.write("---\n\n");
 
     for (Rule rule : grammar.getRules()) {

--- a/src/main/java/net/nextencia/rrdiagram/Main.java
+++ b/src/main/java/net/nextencia/rrdiagram/Main.java
@@ -113,7 +113,6 @@ public class Main {
     pw.write("---\n");
     pw.write("title: Grammar Diagrams\n");
     pw.write("summary: Diagrams of the grammar rules.\n");
-    pw.write("type: docs\n");
     pw.write("---\n\n");
 
     for (Rule rule : grammar.getRules()) {


### PR DESCRIPTION
Need to add some frontmatter to make this file render correctly in the new docs site.