### PR TITLE
Use Arrays.contains() instead of Arrays.binarySearch() to check if the font exists in the system.

### DIFF
--- a/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
+++ b/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
@@ -23,7 +23,7 @@ public class RRDiagramToSVG {
   public static boolean isFontInstalled() {
     GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
     String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
-    return (Arrays.binarySearch(fontFamilyNames, FONT_FAMILY_NAME) >= 0);
+    return (Arrays.asList(fontFamilyNames).contains(FONT_FAMILY_NAME));
   }
 
   public String convert(RRDiagram rrDiagram) {

--- a/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
+++ b/src/main/java/net/nextencia/rrdiagram/grammar/rrdiagram/RRDiagramToSVG.java
@@ -23,7 +23,7 @@ public class RRDiagramToSVG {
   public static boolean isFontInstalled() {
     GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
     String[] fontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
-    return (Arrays.asList(fontFamilyNames).contains(FONT_FAMILY_NAME));
+    return Arrays.asList(fontFamilyNames).contains(FONT_FAMILY_NAME);
   }
 
   public String convert(RRDiagram rrDiagram) {


### PR DESCRIPTION
For some reason this breaks in Ubuntu. Maybe it's unsorted, maybe some other small bug. But with this change it works for me locally.

Background: https://yugabyte.slack.com/archives/CDQB8MEAU/p1683629504261169?thread_ts=1584024509.223600&cid=CDQB8MEAU